### PR TITLE
fix: 🐛 responsive for swiper categories

### DIFF
--- a/src/components/features/categories/SwiperCategories.tsx
+++ b/src/components/features/categories/SwiperCategories.tsx
@@ -29,20 +29,26 @@ const SwiperCategories = ({
 }: SwiperNavigationProps) => {
     return (
         <Swiper
-            slidesPerView={7}
-            grid={{ rows: 2, fill: 'row' }}
+            slidesPerView={2}
+            grid={{ rows: 1, fill: 'row' }}
             navigation={true}
             spaceBetween={10}
             modules={[Navigation]}
             breakpoints={{
+                1024: {
+                    slidesPerView: 7,
+                    grid: {
+                        rows: 1,
+                    },
+                },
                 768: {
-                    slidesPerView: 3,
+                    slidesPerView: 5,
                     grid: {
                         rows: 1,
                     },
                 },
                 480: {
-                    slidesPerView: 2,
+                    slidesPerView: 3,
                     grid: {
                         rows: 1,
                     },


### PR DESCRIPTION
responsive